### PR TITLE
Make running in the background the default

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -23,7 +23,7 @@ type osVmConfig struct {
 	User            string
 	CloudInitDir    string
 	KsFile          string
-	Background      bool
+	Interactive     bool
 	NoCredentials   bool
 	RemoveVm        bool // Kill the running VM when it exits
 	RemoveDiskImage bool // After exit of the VM, remove the disk image
@@ -53,7 +53,7 @@ func init() {
 
 	runCmd.Flags().StringVar(&diskImageConfigInstance.Filesystem, "filesystem", "", "Override the root filesystem (e.g. xfs, btrfs, ext4)")
 	runCmd.Flags().BoolVar(&vmConfig.NoCredentials, "no-creds", false, "Do not inject default SSH key via credentials; also implies --background")
-	runCmd.Flags().BoolVarP(&vmConfig.Background, "background", "B", false, "Do not spawn SSH, run in background")
+	runCmd.Flags().BoolVarP(&vmConfig.Interactive, "interactive,", "i", false, "Start an SSH session")
 	runCmd.Flags().BoolVar(&vmConfig.RemoveVm, "rm", false, "Remove the VM and it's disk when the SSH session exits. Cannot be used with --background")
 	runCmd.Flags().BoolVar(&vmConfig.Quiet, "quiet", false, "Suppress output from bootc disk creation and VM boot console")
 }
@@ -140,7 +140,7 @@ func doRun(flags *cobra.Command, args []string) error {
 		NoCredentials: vmConfig.NoCredentials,
 		CloudInitData: flags.Flags().Changed("cloudinit"),
 		RemoveVm:      vmConfig.RemoveVm,
-		Background:    vmConfig.Background,
+		Interactive:   vmConfig.Interactive,
 		SSHPort:       sshPort,
 		SSHIdentity:   machineInfo.SSHIdentityPath,
 		VMUser:        vmConfig.User,
@@ -155,7 +155,7 @@ func doRun(flags *cobra.Command, args []string) error {
 		return err
 	}
 
-	if !vmConfig.Background {
+	if vmConfig.Interactive {
 		if !vmConfig.Quiet {
 			var vmConsoleWg sync.WaitGroup
 			vmConsoleWg.Add(1)

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -61,7 +61,7 @@ type RunVMParameters struct {
 	SSHPort       int
 	Cmd           []string
 	RemoveVm      bool
-	Background    bool
+	Interactive   bool
 }
 
 type BootcVM interface {
@@ -88,7 +88,7 @@ type BootcVMCommon struct {
 	sshIdentity   string
 	sshPort       int
 	removeVm      bool
-	background    bool
+	interactive   bool
 	cmd           []string
 	pidFile       string
 	imageID       string

--- a/pkg/vm/vm_darwin.go
+++ b/pkg/vm/vm_darwin.go
@@ -103,7 +103,7 @@ func (b *BootcVMMac) GetConfig() (cfg *BootcVMConfig, err error) {
 func (b *BootcVMMac) Run(params RunVMParameters) (err error) {
 	b.sshPort = params.SSHPort
 	b.removeVm = params.RemoveVm
-	b.background = params.Background
+	b.interactive = params.Interactive
 	b.cmd = params.Cmd
 	b.hasCloudInit = params.CloudInitData
 	b.cloudInitDir = params.CloudInitDir
@@ -112,9 +112,9 @@ func (b *BootcVMMac) Run(params RunVMParameters) (err error) {
 
 	if params.NoCredentials {
 		b.sshIdentity = ""
-		if !b.background {
-			fmt.Print("No credentials provided for SSH, using --background by default")
-			b.background = true
+		if b.interactive {
+			fmt.Print("No credentials provided for SSH, running the VM in the background")
+			b.interactive = false
 		}
 	}
 

--- a/pkg/vm/vm_linux.go
+++ b/pkg/vm/vm_linux.go
@@ -116,7 +116,7 @@ func (v *BootcVMLinux) PrintConsole() (err error) {
 func (v *BootcVMLinux) Run(params RunVMParameters) (err error) {
 	v.sshPort = params.SSHPort
 	v.removeVm = params.RemoveVm
-	v.background = params.Background
+	v.interactive = params.Interactive
 	v.cmd = params.Cmd
 	v.hasCloudInit = params.CloudInitData
 	v.cloudInitDir = params.CloudInitDir
@@ -125,9 +125,9 @@ func (v *BootcVMLinux) Run(params RunVMParameters) (err error) {
 
 	if params.NoCredentials {
 		v.sshIdentity = ""
-		if !v.background {
-			fmt.Print("No credentials provided for SSH, using --background by default")
-			v.background = true
+		if v.interactive {
+			fmt.Print("No credentials provided for SSH, running the VM in the background")
+			v.interactive = false
 		}
 	}
 

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -99,7 +99,7 @@ func runTestVM(bootcVM vm.BootcVM) {
 		SSHPort:       22,
 		Cmd:           []string{},
 		RemoveVm:      false,
-		Background:    false,
+		Interactive:   true,
 		SSHIdentity:   testUserSSHKey,
 	})
 	Expect(err).To(Not(HaveOccurred()))


### PR DESCRIPTION
We are moving to integrate this tool in podman, so we need to follow the podman command line convention. So, let's make running in the background the default behavior requiring `-i/--interactive` to spawn an SSH session.

Related #1 